### PR TITLE
Basic Template for Blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# generated files
+_site/

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,5 @@
 markdown: redcarpet
 highlighter: pygments
+
+paginate: 5
+paginate_path: "/page:num/"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,5 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
+<link rel="stylesheet" href="/css/syntax.css">
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,28 @@
+---
+layout: post
+---
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% include head.html %}
+    <title>{{ page.title }}</title>
+  </head>
+  <body>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <h1>{{ page.title }}</h1>
+          <small>{{ page.date | date: '%B %d, %Y' }}</small>
+          <small>|</small>
+          <small>Author: {{ page.author }}</small>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          {{ content }}
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/_posts/2015-02-19-parsing-a-body-anatomy-tree.md
+++ b/_posts/2015-02-19-parsing-a-body-anatomy-tree.md
@@ -1,0 +1,108 @@
+---
+layout: post
+title: Parsing a Body Anatomy Tree
+author: Michael Tu
+---
+
+Recently I finished working on constructing a human body tree so that relations extracted from the [Knowledge Extraction](https://github.com/crea-berkeley/relation-extraction) project could be associated with parts of the human body. In this blog post I would like to discuss the process I went through to decode a text file that encodes information about the anatomy of the human body and produce a JSON file representing this hierarchical structure.
+
+The input file that encodes the various parts of the human body, from larger components such as organs to smaller components such as cells, is a text file of unknown format. I will refer to this file as the *tree* file from this point onwards. The tree file was produced a while ago and nobody remembers exactly how it was encoded. The only other hint is that there is a PHP script that the author made to work with this file, so it might provide clues on how to decode the tree. Here is a snippet of the tree file:
+
+```
+a:2:{i:0;a:3014:{i:0;a:10:{i:0;a:1:{i:0;s:12:"body anatomy";}i:1;i:3014;i:2;a:3:{i:0;i:817;i:1;i:2374;i:2;i:2437;}i:3;i:0;i:4;s:1:"0";i:7;i:0;i:8;s:0:"";s:14:"default_parent";N;s:3:"sex";s:1:"m";s:13:"node_keywords";a:1:{s:4:"body";a:0:{}}}i:156;a:11:{i:0;a:1:{i:0;s:13:"palatine bone";}i:1;a:2:{i:0;s:3:"971";i:1;s:3:"642";}i:2;a:4:{i:0;i:2333;i:1;i:2342;i:2;i:2343;i:3;s:4:"2332";}i:3;i:0;i:4;s:1:"0";i:6;s:1:"0";i:7;i:0;i:8;s:0:"";s:14:"default_parent";s:3:"971";s:15:"parent_keywords";a:2:{i:971;a:3:{i:0;s:4:"bone";i:1;s:11:"facial bone";i:2;s:8:"skeleton";}i:642;a:1:{i:0;s:6:"palate";}}...
+```
+
+The entire file is approximately 1 megabyte large. By simply looking at this file, one can decipher a small amount of information. For example, the ‘i’ seems to refer to a node id, the number following ‘s:’ seems to refer to the length of the string following it, and braces likely indicate some parent-child relationship. But I wanted to work with this file in a more straightforward manner with less hypothesizing about what the syntax meant, so I examined the PHP script for some inspiration. The decision proved to be helpful as I found out that this is not an arbitrary format that the author came up with him or herself, but rather it is how PHP serializes objects. These were the lines in the PHP file that led to my realization:
+
+```php
+$str = implode("", file($tree_files_dir.$this->name));
+$this->nodes = unserialize($str);
+$this->nodes_hash = array();
+```
+I decided to write the program that produced the final JSON output in either Python or Java. The initial approach that I took was I found libraries that can parse this PHP file into native objects in the languages I will be working in, such as [phpserialize](https://pypi.python.org/pypi/phpserialize) for Python and [pherialize](https://github.com/kayahr/pherialize) for Java. Later however I decided to modify the PHP script to produce a JSON output that I can then work with directly instead of using external libraries to parse the serialized PHP objects. Note that this intermediate structure, although it is in JSON, still needs to be processed because it is a flattened tree. Here is a snippet of this flattened tree structure:
+
+```json
+{
+    "0": {
+        "0": [
+            "body anatomy"
+        ],
+        "1": 3014,
+        "2": [
+            817,
+            2374,
+            2437
+        ],
+        "3": 0,
+        "4": "0",
+        "7": 0,
+        "8": "",
+        ...
+    },
+   ...
+}
+```
+
+Each node is keyed by its ID and here are its most important key value pairs:
+
+- “0”: A list of names for this node.
+- “1”: A list of parents for this node. Note that the root node is an exception, where it is an integer representing the number of types of child nodes.
+- “2”: A list of children for this node.
+
+With the structure of the flat tree known, the next step would be devise an algorithm to construct the tree which would convert this flat structure into a hierarchical structure mirroring the hierarchical organization of organs, tissues, cells, etc.. Algorithms that naturally come to mind are based on the ideas of depth-first search and breadth-first search. The difference here is that instead of a search, we are constructing the tree from the root node either using a depth-first or breadth-first approach. I picked a depth-first approach but a breadth-first approach can work as well.
+
+In the depth-first tree construction strategy, recursion is used just as in depth-first search. The base case is when a node has no children, in which the function returns. The recursive step is to nest the nodes identified by the child IDs of the current node in the current node itself, and repeat this for the children’s children. For example, if the current node has two children, with IDs 983 and 156, which refers to *maxillary bone* and *palatine bone* respectively, the current step would put the nodes that correspond with the *maxillary bone* and *palatine bone* as children nested inside the current node, instead of just having a the node IDs 983 and 156 referring to the children. Here are some figures to illustrate this action:
+
+At the beginning of the current recursion level, our node could look like this:
+
+```json
+{
+    "id": 642,
+    "names": ["hard palate"],
+    "children": [983, 156]
+}
+```
+
+At the end of the current recursion level, our node could look like this:
+
+```json
+{
+    "id": 642,
+    "names": ["hard palate"],
+    "children": [
+        {
+            "id": 983,
+            "names": ["maxilla", "maxillary bone"],
+            "children": [...]
+        },
+        {
+            "id": 156,
+            "names": ["palatine bone"],
+            "children": [...]
+        }
+    ]
+}
+```
+
+
+Now that we have an algorithm, we could feed it the input and see if it can successfully output the JSON in the format we want. I implemented the algorithm in Java in the end. What I observed, however, was that the recursion never stops, and will eventually cause the stack to overflow. After some time investigating the cause, I determined that the structure that I thought was a tree actually contains cycles. I kept track of the frequency of the visits to each node ID while debugging the infinite recursion, and discovered that there are a few nodes with thousands of visits while others have 0 after around a bound number of recursive steps (~100000). Here is an example of a cycle:
+
+```json
+{
+    "id": 642,
+    "names": ["hard palate"],
+    "children": [
+        {
+            "id": 2855,
+            "names": ["palatal process", "palatine process"],
+            "children": [642, 2858, 2859]
+        }
+    ]
+}
+```
+
+Note that the node with ID 2855 has a child that has the same ID as its parent.
+
+The way this can be solved is by keeping track of all the ancestors of a node as we are traversing down the tree we are constructing by ID. If we detect that a child has the same ID as an ancestor we can stop recursing on that child, indicate we have encountered a cycle, and continue on. With this change, the program can terminate successfully.
+
+Source files for the body anatomy tree constructor can be found at: [https://github.com/crea-berkeley/crea-anatomy-tree-builder](https://github.com/crea-berkeley/crea-anatomy-tree-builder).

--- a/css/syntax.css
+++ b/css/syntax.css
@@ -1,0 +1,60 @@
+.highlight  { background: #ffffff; }
+.highlight .c { color: #999988; font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .k { font-weight: bold } /* Keyword */
+.highlight .o { font-weight: bold } /* Operator */
+.highlight .cm { color: #999988; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #999999; font-weight: bold } /* Comment.Preproc */
+.highlight .c1 { color: #999988; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
+.highlight .gd .x { color: #000000; background-color: #ffaaaa } /* Generic.Deleted.Specific */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #aa0000 } /* Generic.Error */
+.highlight .gh { color: #999999 } /* Generic.Heading */
+.highlight .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+.highlight .gi .x { color: #000000; background-color: #aaffaa } /* Generic.Inserted.Specific */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #555555 } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #aaaaaa } /* Generic.Subheading */
+.highlight .gt { color: #aa0000 } /* Generic.Traceback */
+.highlight .kc { font-weight: bold } /* Keyword.Constant */
+.highlight .kd { font-weight: bold } /* Keyword.Declaration */
+.highlight .kp { font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #445588; font-weight: bold } /* Keyword.Type */
+.highlight .m { color: #009999 } /* Literal.Number */
+.highlight .s { color: #d14 } /* Literal.String */
+.highlight .na { color: #008080 } /* Name.Attribute */
+.highlight .nb { color: #0086B3 } /* Name.Builtin */
+.highlight .nc { color: #445588; font-weight: bold } /* Name.Class */
+.highlight .no { color: #008080 } /* Name.Constant */
+.highlight .ni { color: #800080 } /* Name.Entity */
+.highlight .ne { color: #990000; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #990000; font-weight: bold } /* Name.Function */
+.highlight .nn { color: #555555 } /* Name.Namespace */
+.highlight .nt { color: #000080 } /* Name.Tag */
+.highlight .nv { color: #008080 } /* Name.Variable */
+.highlight .ow { font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mf { color: #009999 } /* Literal.Number.Float */
+.highlight .mh { color: #009999 } /* Literal.Number.Hex */
+.highlight .mi { color: #009999 } /* Literal.Number.Integer */
+.highlight .mo { color: #009999 } /* Literal.Number.Oct */
+.highlight .sb { color: #d14 } /* Literal.String.Backtick */
+.highlight .sc { color: #d14 } /* Literal.String.Char */
+.highlight .sd { color: #d14 } /* Literal.String.Doc */
+.highlight .s2 { color: #d14 } /* Literal.String.Double */
+.highlight .se { color: #d14 } /* Literal.String.Escape */
+.highlight .sh { color: #d14 } /* Literal.String.Heredoc */
+.highlight .si { color: #d14 } /* Literal.String.Interpol */
+.highlight .sx { color: #d14 } /* Literal.String.Other */
+.highlight .sr { color: #009926 } /* Literal.String.Regex */
+.highlight .s1 { color: #d14 } /* Literal.String.Single */
+.highlight .ss { color: #990073 } /* Literal.String.Symbol */
+.highlight .bp { color: #999999 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #008080 } /* Name.Variable.Class */
+.highlight .vg { color: #008080 } /* Name.Variable.Global */
+.highlight .vi { color: #008080 } /* Name.Variable.Instance */
+.highlight .il { color: #009999 } /* Literal.Number.Integer.Long */

--- a/index.html
+++ b/index.html
@@ -1,0 +1,89 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% include head.html %}
+    <title>CREA GitHub Blog</title>
+  </head>
+  <body>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <h1>CREA GitHub Blog</h1>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-md-12">
+          {% if paginator.posts.size > 0 %}
+            {% for post in paginator.posts %}
+            <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            <p class="author">
+              <span class="date">{{ post.date | date: '%B %d, %Y' }}</span>
+              <span>|</span>
+              <span>Author: {{ post.author }}</span>
+            </p>
+            <div>
+              <p>{{ post.excerpt }}</p>
+            </div>
+            {% endfor %}
+          {% else %}
+            <p class="top-buffer">There are no blog posts currently available.</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-md-12">
+          <!-- Bootstrap style pagination -->
+          <div class="text-center">
+            {% if paginator.total_pages > 1 %}
+            <nav>
+              <ul class="pagination">
+                {% if paginator.previous_page %}
+                <li>
+                  <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                  </a>
+                </li>
+                {% else %}
+                <li class="disabled">
+                  <a href="#" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                  </a>
+                </li>
+                {% endif %}
+
+                {% for page in (1..paginator.total_pages) %}
+                {% if page == paginator.page %}
+                <li class="active"><a href="#">{{ page }}</a></li>
+                {% elsif page == 1 %}
+                <li><a href="{{ '/index.html' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a></li>
+                {% else %}
+                <li><a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a></li>
+                {% endif %}
+                {% endfor %}
+
+                {% if paginator.next_page %}
+                <li>
+                  <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                  </a>
+                </li>
+                {% else %}
+                <li class="disabled">
+                  <a href="#" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                  </a>
+                </li>
+                {% endif %}
+              </ul>
+            </nav>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
             </div>
             {% endfor %}
           {% else %}
-            <p class="top-buffer">There are no blog posts currently available.</p>
+            <p>There are no blog posts currently available.</p>
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
Have a basic index page that can display blog post titles and excerpts with pagination support. Pagination can be configued in _config.yml. When a blog post title is clicked, the blog post page opens.

The head.html file in _includes contains common lines that should be added in HTML files. For example, importing Bootstrap is done inside here.

Also have a syntax.css file for code highlighting.

To run, pull this branch. In terminal, inside the root directory of the repo, enter `jekyll serve` and then go to [localhost:4000](http://localhost:4000).

@markfarrell please review.
